### PR TITLE
Feat/#73 로그인 시 사용자 메타이미지 반영

### DIFF
--- a/src/api/userAuthService.js
+++ b/src/api/userAuthService.js
@@ -121,3 +121,24 @@ export const authKakaoSignIn = async () => {
     throw new Error(`카카오 로그인 실패: ${error.message}`);
   }
 };
+
+/**
+ * @function updateUserProfile
+ * @description 로그인한 사용자의 프로필 사진을 데이터베이스에 업데이트하는 비동기 함수
+ * @async
+ * @returns {Promise<Object>} 프로필 사진 반영 성공 시 반환 데이터
+ * @throws {Error} 프로필 사진 반영 실패 시 오류 발생
+ */
+export const updateUserProfile = async (session) => {
+  if (!session?.user) return;
+
+  const { id } = session.user;
+  const profileImage = session.user.user_metadata.picture;
+
+  const { error } = await supabase
+    .from('users')
+    .update({ profile_img: profileImage })
+    .eq('user_id', id);
+
+  if (error) console.error('프로필 업데이트 실패:', error);
+};

--- a/src/store/userStore.js
+++ b/src/store/userStore.js
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { supabase } from '../api/client';
 import { persist } from 'zustand/middleware';
+import { updateUserProfile } from '../api/userAuthService';
 
 const useUserStore = create(
   persist(
@@ -25,6 +26,7 @@ export const handleAuthStateChange = async () => {
     (event, session) => {
       if (event === 'SIGNED_IN' && session) {
         setUser(session.user);
+        updateUserProfile(session); // 구글 / 카카오 프로필 사진 반영
       } else if (event === 'SIGNED_OUT') {
         clearUser();
       }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #73

<br>

## 📝 작업 내용

> 구글, 카카오 로그인 시 확인할 수 있는 `session`의 유저 이미지를 `onAuthChange` 의 `SIGNED_IN` 이벤트가 발생했을 때 자동으로 publci - users 테이블에 반영되게 합니다.

<br>


## 💬리뷰 요구사항

> 리뷰 예상 시간 : `3분`