### PR TITLE
Style/#78 product list page UI

### DIFF
--- a/src/components/common/HighlightText.jsx
+++ b/src/components/common/HighlightText.jsx
@@ -1,7 +1,6 @@
 const HighlightText = ({ children }) => {
   return (
-    <span className="relative inline-block mr-1">
-      <span className="absolute bottom-0 left-0 right-0 top-auto bg-point-color2 h-3/5"></span>
+    <span className="relative inline-block mr-1 before:content-[''] before:absolute before:bottom-0 before:left-0 before:right-0 before:h-3/5 before:bg-point-color2">
       <span className="relative">{children}</span>
     </span>
   );

--- a/src/components/layout/Nav.jsx
+++ b/src/components/layout/Nav.jsx
@@ -14,7 +14,7 @@ const Nav = () => {
   const isLoading = !user ? false : isPending;
 
   return (
-    <nav className="fixed top-0 flex items-center justify-between w-full h-[60px] bg-deep-mint px-7 text-white text-base font-light shadow-sm">
+    <nav className="z-9999 fixed top-0 flex items-center justify-between w-full h-[60px] bg-deep-mint px-7 text-white text-base font-light shadow-sm">
       <h1>
         <Link to="/product">
           <img src="/Logo.jpeg" className="h-14" />

--- a/src/components/layout/NavAuthStatus.jsx
+++ b/src/components/layout/NavAuthStatus.jsx
@@ -11,7 +11,7 @@ const NavAuthStatus = ({ isLoading, userData }) => {
       <UserDropDown userData={userData} />
     </div>
   ) : (
-    <div className="flex gap-2">
+    <div className="flex gap-7">
       <Link to="/signin">로그인</Link>
       <Link to="/signup">회원가입</Link>
     </div>

--- a/src/pages/ProductList.jsx
+++ b/src/pages/ProductList.jsx
@@ -13,7 +13,7 @@ const ProductList = () => {
   const { data: products, isLoading } = useGetProducts(search);
 
   return (
-    <div className="flex flex-col w-full h-[calc(100vh-60px)] overflow-hidden md:flex-row">
+    <div className="flex flex-col w-full h-[100vh] pt-[60px] overflow-hidden md:flex-row">
       {/* 검색바는 항상 유지 */}
       <div className="w-full border-r border-light-gray h-full bg-white md:w-[360px]">
         <SearchBar setSearch={setSearch} />
@@ -29,8 +29,8 @@ const ProductList = () => {
       </div>
 
       {/* 지도 부분도 데이터 로딩 여부에 따라 변경 */}
-      <div className="flex flex-col flex-grow w-full p-4 md:w-3/4">
-        <span className="p-4 text-2xl">
+      <div className="flex gap-[84px] flex-col flex-grow w-full my-[130px] mx-[90px] md:w-3/4">
+        <span className="font-semibold text-title-md">
           {search ? (
             <>
               <HighlightText>"{search}"</HighlightText>에 대한 검색 결과

--- a/src/routes/AllowedRoute.jsx
+++ b/src/routes/AllowedRoute.jsx
@@ -26,7 +26,9 @@ const AllowedRoute = ({ children }) => {
         </h1>
       </div>
     ) : (
-      <div className="flex-grow full min-h-[400px] rounded-lg overflow-hidden border border-light-gray m-10">{children}</div>
+      <div className="flex-grow full min-h-[400px] rounded-[65px] overflow-hidden border border-light-gray">
+        {children}
+      </div>
     );
   }
   return isLocationAllowed ? <Outlet /> : <Navigate to="/product" />;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #78 

<br>

## 📝 작업 내용

> 기존 시안이랑 CSS를 비교했을때 다른 부분이 많아서 위치를 재조정 했습니다.
nav bar에 있는 로그인 회원가입 버튼 사이 간격을 수정했고 z-index 적용시켜 최상위 layer에 위치시켰습니다.
highlight text 에는 before 가상요소를 이용해 배경을 표현했습니다.
지도 내부에만 있던 마진을 삭제하고 highlight text 사이에 gap으로 간격을 설정했습니다.
지도 border-radius 값을 rounded-xl에서 65px로 수정했습니다.

<br>

## 🖼 스크린샷
![지도 수정본](https://github.com/user-attachments/assets/b3990d73-aac1-44d6-9434-cf583f31fcbd)

<br>